### PR TITLE
Add Copyright information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
  - python >= 2.6
  - setprocname: to have cleaner names in ps for the daemons (not required)
+ - fast-entry_points
 
 ## Installation
 
@@ -82,8 +83,11 @@ Feature request with documentation, fixes, new features and general beutificatio
 
 ## Open source licensing info
 
+Copyright: SVT 2018
 GNU General Public License version 3
 [LICENSE](LICENSE)
 
-----
+except for [fastentrypoints.py](https://github.com/ninjaaron/fast-entry_points) which is Copyright (c) 2016, Aaron Christianson 
+
+---
 

--- a/bumpversion.py
+++ b/bumpversion.py
@@ -1,5 +1,26 @@
 #!/usr/bin/env python
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 
 package = "src"
 
@@ -85,4 +106,5 @@ for line in open(versionfile).readlines():
 	else:
 		buff += line
 open(versionfile,"wb").write(buff)
+
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,27 @@
 # -*- coding: utf-8 -*-
 # vim: ts=4 sw=4 et bg=dark
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 import os
 from setuptools import setup
 #import fastentrypoints
@@ -39,4 +60,5 @@ setup(
     },
     install_requires=src.dependencies,
 )
+
 

--- a/src/api.py
+++ b/src/api.py
@@ -2,6 +2,27 @@
 # coding: utf8
 # vim: ts=4 sw=4 et bg=dark
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 from subprocess import Popen,PIPE,STDOUT
 
 class DaemonCLTError(Exception): pass
@@ -80,3 +101,4 @@ if __name__ == '__main__':
     #print d.start("haserver")
     #printStatus()
         
+

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -2,6 +2,27 @@
 # coding: utf8
 # vim: ts=4 sw=4 et bg=dark
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 
 import os
 import resource
@@ -43,4 +64,5 @@ def daemonize():
    os.dup2(0, 2) # stderr
 
    return True
+
 

--- a/src/daemonconfig.py
+++ b/src/daemonconfig.py
@@ -1,5 +1,26 @@
 #!/usr/bin/python
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 class ConfigFileError(Exception): pass
 
 
@@ -120,4 +141,5 @@ if __name__ == "__main__":
 	print(c["programname"])
 	print(c.apa.mandel["1"].grejs)
 	print(c.list("ingest"))
+
 

--- a/src/daemonlog.py
+++ b/src/daemonlog.py
@@ -5,6 +5,27 @@
 # Module for handling fancy logging
 #
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 from sys import exc_info
 from threading import current_thread
 from traceback import format_exc, format_exception, format_stack
@@ -84,4 +105,5 @@ if __name__ == '__main__':
     def apa2():
         apa()
     apa2()
+
 

--- a/src/dts.py
+++ b/src/dts.py
@@ -2,6 +2,27 @@
 # coding: utf8
 # vim: ts=4 sw=4 et bg=dark
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 import sys,os
 import logging
 from select import select
@@ -175,4 +196,5 @@ def serve_forever():
                 m.handleSockets(ins)
     except KeyboardInterrupt:
         log.info("Exiting. CTRL-C pressed")
+
 

--- a/src/fulltb.py
+++ b/src/fulltb.py
@@ -3,6 +3,27 @@
 # From user4815162342 on stackoverflow
 # https://stackoverflow.com/questions/13210436/get-full-traceback
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 import sys
 
 class FauxTb(object):
@@ -35,3 +56,4 @@ def full_exc_info(skip=0):
     t, v, tb = sys.exc_info()
     full_tb = extend_traceback(tb, current_stack(skip+1))
     return t, v, full_tb
+

--- a/src/locks.py
+++ b/src/locks.py
@@ -2,6 +2,27 @@
 # coding: utf8
 # vim: ts=4 sw=4 et bg=dark
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 import os,sys
 from time import time,sleep
 if sys.version_info[0] >= 3:
@@ -103,3 +124,4 @@ class FileLock:
 
     def close(self):
         self.unlock()
+

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,27 @@
 #!/usr/bin/env python
 # vim: ts=4 sw=4 et
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 from __future__ import print_function
 
 import sys,os
@@ -569,3 +590,4 @@ def main():
         print("No daemon match %r"%(filtertext,),file=sys.stderr)
 if __name__ == "__main__":
     main()
+

--- a/src/piptool.py
+++ b/src/piptool.py
@@ -2,6 +2,27 @@
 # -*- coding: utf8 -*-
 # vim: ts=4 sw=4 et bg=dark
 
+"""
+  This file is part of daemonctl.
+  Copyright (C) 2018 SVT
+  
+  daemonctl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+ 
+  daemonctl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with daemonctl.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+
+
 # Module for loading modules through pip entry points (daemonctl.modules entry group)
 
 from pkg_resources import iter_entry_points
@@ -145,3 +166,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
Even if not a must, it is recommended practice to add the GPLv3
information is added to the file headers. Also, we use a file from
another project, fastentrypoint, and that was made clear in the
README.md